### PR TITLE
Fix Spec Actions bug

### DIFF
--- a/dist/js/run.js
+++ b/dist/js/run.js
@@ -407,6 +407,7 @@ async function setNavigationState(showNavigation = null) {
 function attachSpecificationEvents(formElement) {
     formElement.addEventListener("FormUpdated", event => {
         formUpdated(event);
+        renderSpecificationActions();
     });
 
     formElement.addEventListener("ActionsUpdated", async () => {


### PR DESCRIPTION
Changing the behavior of the form control actions to update the available list even if just a form control value has changed instead of only if the text or hidden property changed.